### PR TITLE
fix twitter && github links

### DIFF
--- a/pelicanconf.py
+++ b/pelicanconf.py
@@ -34,8 +34,8 @@ LINKS = (('Pelican', 'http://getpelican.com/'),
 # Social widget
 SOCIAL = (
     ('keybase', 'https://keybase.io/kourier'),
-    ('github', 'https://github.com/qrkourier'),
     ('twitter', 'https://twitter.com/qrkourier'),
+    ('github', 'https://github.com/qrkourier'),
     ('reddit', 'https://www.reddit.com/user/bingnet'),
 )
 


### PR DESCRIPTION
Currently the twitter icon links to github and the other way around as well. I think it's just an ordering problem most likely.